### PR TITLE
Add year to search queries

### DIFF
--- a/src/dom/tmdbQueryFromPage.ts
+++ b/src/dom/tmdbQueryFromPage.ts
@@ -22,7 +22,8 @@ export function tmdbQueryFromPage(process = true) {
       : post.startsWith("Movie")
       ? TmdbMediaType.Movie
       : false;
-
+  const yearMatch = name.match(/\((\d{4})\)/);
+  const year = yearMatch ? yearMatch[1] : null;
   if (!type) {
     return false;
   }
@@ -31,5 +32,6 @@ export function tmdbQueryFromPage(process = true) {
   return {
     type,
     name: process ? preprocessors.reduce((acc, fn) => fn(acc), name) : name,
+    year,
   };
 }

--- a/src/dom/tmdbQueryFromPage.ts
+++ b/src/dom/tmdbQueryFromPage.ts
@@ -22,13 +22,14 @@ export function tmdbQueryFromPage(process = true) {
       : post.startsWith("Movie")
       ? TmdbMediaType.Movie
       : false;
-  const yearMatch = name.match(/\((\d{4})\)/);
-  const year = yearMatch ? yearMatch[1] : null;
+
   if (!type) {
     return false;
   }
 
   const name = s.join(" - ");
+  const yearMatch = post.match(/\[(\d{4})\]/);
+  const year = yearMatch[1];
   return {
     type,
     name: process ? preprocessors.reduce((acc, fn) => fn(acc), name) : name,

--- a/src/dom/tmdbQueryFromPage.ts
+++ b/src/dom/tmdbQueryFromPage.ts
@@ -17,7 +17,7 @@ export function tmdbQueryFromPage(process = true) {
   const s = $("#content > div.thin > h2:first-child").text().split(" - ");
   const post = s.pop();
   const type =
-    post.startsWith("TV Series") || post.startsWith("ONA")
+    post.startsWith("TV Series") || post.startsWith("ONA") || post.startsWith("OVA")
       ? TmdbMediaType.Tv
       : post.startsWith("Movie")
       ? TmdbMediaType.Movie

--- a/src/helpers/ensureTmdbItem.ts
+++ b/src/helpers/ensureTmdbItem.ts
@@ -11,7 +11,7 @@ async function tmdbItem(): Promise<TmdbItem | false> {
   }
   log("Media detected on page:", mip);
 
-  const id = await TmdbProvider.identify(mip.type, mip.name);
+  const id = await TmdbProvider.identify(mip.type, mip.name, mip.year);
   if (!id) {
     log("Could not identify media against TMDB");
     return false;

--- a/src/providers/TmdbProvider.ts
+++ b/src/providers/TmdbProvider.ts
@@ -112,11 +112,7 @@ export class TmdbProvider extends MetadataProvider {
     url.searchParams.set("query", name);
     // Add year to the query if available
     if (year) {
-        if (type === TmdbMediaType.Movie) {
             url.searchParams.set("year", year);
-        } else if (type === TmdbMediaType.Tv) {
-            url.searchParams.set("first_air_date_year", year);
-        }
     }
     log(`fetching ${url.toString()}`);
     url.searchParams.set(

--- a/src/providers/TmdbProvider.ts
+++ b/src/providers/TmdbProvider.ts
@@ -82,9 +82,10 @@ export class TmdbProvider extends MetadataProvider {
 
   static async identify(
     type: TmdbMediaType,
-    name: string
+    name: string,
+    year: string
   ): Promise<TmdbIdentified | false> {
-    const key = `tmdb_${type}_by_name_${name}`;
+    const key = `tmdb_${type}_by_name_${name}${year ? `_by_year_${year}` : ''}`;
     const cached = checkCache(key, 1000 * 60 * 60 * 24 * 3); // 3 days
 
     // Try reduced query (will probably also be cached)
@@ -93,7 +94,7 @@ export class TmdbProvider extends MetadataProvider {
 
       if (reducedName) {
         log(`trying reduced query ${reducedName}`);
-        return await this.identify(type, reducedName);
+        return await this.identify(type, reducedName, year);
       }
 
       return false;
@@ -109,6 +110,14 @@ export class TmdbProvider extends MetadataProvider {
     url.searchParams.set("include_adult", "true");
     url.searchParams.set("language", TMDB_LANGUAGE);
     url.searchParams.set("query", name);
+    // Add year to the query if available
+    if (year) {
+        if (type === TmdbMediaType.Movie) {
+            url.searchParams.set("year", year);
+        } else if (type === TmdbMediaType.Tv) {
+            url.searchParams.set("first_air_date_year", year);
+        }
+    }
     log(`fetching ${url.toString()}`);
     url.searchParams.set(
       "api_key",
@@ -129,7 +138,7 @@ export class TmdbProvider extends MetadataProvider {
       const reducedName = this.reduceNameQuery(name);
 
       if (reducedName) {
-        return await this.identify(type, reducedName);
+        return await this.identify(type, reducedName, year);
       }
 
       return false;


### PR DESCRIPTION
There are some series and movies with the same name but different years, searching TMDB with name + year would give more accurate results. I also added OVAs to TV-type search query, as they are usually attached to a season, or a series in general.